### PR TITLE
prerelease 22/03/2023 hotfix patch for mempool

### DIFF
--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -20,7 +20,11 @@ static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 2000000;
 static const unsigned int DEFAULT_BLOCK_PRIORITY_SIZE = 10000; // was 50000 in 0.12.0 and it is 0 in Bitcoin since 0.12
 /** Default for -blockmintxfee, which sets the minimum feerate for a transaction in blocks created by mining code **/
 static const unsigned int DEFAULT_BLOCK_MIN_TX_FEE = 1000;
-/** The maximum size for transactions we're willing to relay/mine */
+/** The maximum size for transactions we're willing to relay/mine */.
+
+//22/03/2023 MEMPOOL ISSUE HARDFORK 
+//static const unsigned int MAX_STANDARD_TX_SIZE = 250000;
+
 static const unsigned int MAX_STANDARD_TX_SIZE = 100000;
 /** Maximum number of signature check operations in an IsStandard() P2SH script */
 static const unsigned int MAX_P2SH_SIGOPS = 15;
@@ -29,12 +33,20 @@ static const unsigned int MAX_STANDARD_TX_SIGOPS = 4000;
 /** Default for -maxmempool, maximum megabytes of mempool memory usage */
 static const unsigned int DEFAULT_MAX_MEMPOOL_SIZE = 300;
 /** Default for -incrementalrelayfee, which sets the minimum feerate increase for mempool limiting or BIP 125 replacement **/
+
+//22/03/2023 MEMPOOL ISSUE HARDFORK 
+//static const unsigned int DEFAULT_INCREMENTAL_RELAY_FEE = 5;
+
 static const unsigned int DEFAULT_INCREMENTAL_RELAY_FEE = 1000;
 /** Min feerate for defining dust. Historically this has been the same as the
  * minRelayTxFee, however changing the dust limit changes which transactions are
  * standard and should be done with care and ideally rarely. It makes sense to
  * only increase the dust limit after prior releases were already not creating
  * outputs below the new threshold */
+ 
+//22/03/2023 MEMPOOL ISSUE HARDFORK 
+//static const unsigned int DUST_RELAY_TX_FEE = 5;
+
 static const unsigned int DUST_RELAY_TX_FEE = 1000;
 /**
  * Standard script verification flags that standard transactions will comply

--- a/src/validation.h
+++ b/src/validation.h
@@ -57,10 +57,20 @@ static const bool DEFAULT_WHITELISTRELAY = true;
 /** Default for DEFAULT_WHITELISTFORCERELAY. */
 static const bool DEFAULT_WHITELISTFORCERELAY = true;
 /** Default for -minrelaytxfee, minimum relay fee for transactions */
+//22/03/2023 MEMPOOL ISSUE HARDFORK 
+
+
+// static const unsigned int DEFAULT_MIN_RELAY_TX_FEE = 1000;
 static const unsigned int DEFAULT_MIN_RELAY_TX_FEE = 100000;
 //! -maxtxfee default
+
+//22/03/2023 MEMPOOL ISSUE HARDFORK 
+// static const CAmount DEFAULT_TRANSACTION_MAXFEE = 1000000 * COIN;
 static const CAmount DEFAULT_TRANSACTION_MAXFEE = 1000 * COIN;
 //! Discourage users to set fees higher than this amount  per kB
+
+//22/03/2023 MEMPOOL ISSUE HARDFORK 
+//static const CAmount HIGH_TX_FEE_PER_KB = 1000000 * COIN;
 static const CAmount HIGH_TX_FEE_PER_KB = 100 * COIN;
 //! -maxtxfee will warn if called with a higher fee than this amount
 static const CAmount HIGH_MAX_TX_FEE = 100 * HIGH_TX_FEE_PER_KB;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -53,8 +53,13 @@ static const CAmount DEFAULT_TRANSACTION_FEE = 0;
 //! -fallbackfee default
 static const CAmount DEFAULT_FALLBACK_FEE = 1000;
 //! -mintxfee default
+//22/03/2023 MEMPOOL ISSUE HARDFORK 
+//static const CAmount DEFAULT_TRANSACTION_MINFEE = 1000;
 static const CAmount DEFAULT_TRANSACTION_MINFEE = 100000;
 //! minimum recommended increment for BIP 125 replacement txs
+
+//22/03/2023 MEMPOOL ISSUE HARDFORK 
+//static const CAmount WALLET_INCREMENTAL_RELAY_FEE = 10;
 static const CAmount WALLET_INCREMENTAL_RELAY_FEE = 1000;
 //! target minimum change amount
 static const CAmount MIN_CHANGE = CENT;


### PR DESCRIPTION
MEMPOOL patch due to values exceeding 100KB on VHH 100 000 000 , due to the early stage of the coin this patch can be done under future policies